### PR TITLE
Add auto-assignment GitHub Actions script

### DIFF
--- a/.github/workflows/auto-assignment.yml
+++ b/.github/workflows/auto-assignment.yml
@@ -1,0 +1,33 @@
+name: auto-assignment
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run auto-assignment script
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const path = require('path');
+            const { pathToFileURL } = require('url');
+
+            const filePath = path.resolve('./scripts/auto-assignment.mjs');
+            const fileUrl = pathToFileURL(filePath).href;
+
+            const importedModule = await import(fileUrl);
+            await importedModule.default({ github, context });

--- a/scripts/auto-assignment.mjs
+++ b/scripts/auto-assignment.mjs
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export default async function autoAssign({ github, context }) {
+  let issueNumber;
+  let activeAssigneesList;
+
+  // Hardcoded assignee lists
+  const issueAssigneesList = ['Varun-S10'];
+  const prAssigneesList = ['Varun-S10'];
+
+  // Determine event type
+  if (context.payload.issue) {
+    issueNumber = context.payload.issue.number;
+    activeAssigneesList = issueAssigneesList;
+    console.log('Event Type: Issue');
+  } else if (context.payload.pull_request) {
+    issueNumber = context.payload.pull_request.number;
+    activeAssigneesList = prAssigneesList;
+    console.log('Event Type: Pull Request');
+  } else {
+    console.log('Not an Issue or PR event');
+    return;
+  }
+
+  if (!activeAssigneesList || activeAssigneesList.length === 0) {
+    console.log('No assignees configured.');
+    return;
+  }
+
+  // Round-robin assignment
+  const selection = issueNumber % activeAssigneesList.length;
+  const assigneeToAssign = activeAssigneesList[selection];
+
+  console.log(`Assigning #${issueNumber} to ${assigneeToAssign}`);
+
+  await github.rest.issues.addAssignees({
+    issue_number: issueNumber,
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    assignees: [assigneeToAssign],
+  });
+}


### PR DESCRIPTION
**Add Auto-Assignment GitHub Action**
This PR introduces a GitHub Actions workflow that automatically assigns new issues and pull requests to a designated team member. It ensures that every new task gets immediate ownership and avoid unassigned work items.

**How It Works**

**1. Trigger Events**

- The workflow runs whenever a new issue or pull request is opened.

**2. Determine Assignees**

- It has separate lists for issues and PRs
- The assignee is selected using round-robin logic based on the issue/PR number, so work is distributed consistently.

**3. Automatic Assignment**

- Once selected, the workflow assigns the issue/PR via the GitHub API.

**Why This Is Needed**

- Prevents new issues and PRs from being unassigned.
- Ensures even distribution of tasks among team members.
- Saves manual effort in assigning every new item.