### PR TITLE
Add stale issue auditor with automated analysis and reporting

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -1,0 +1,61 @@
+name: ADK Stale Issue Auditor (JS)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '*/5 * * * *'
+
+jobs:
+  audit-stale-issues:
+    if: github.repository == 'Varun-S10/adk-js'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    permissions:
+      issues: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: |
+          npm install
+          npm install axios axios-retry luxon date-fns
+          npm install --save-dev ts-node typescript @types/node @types/luxon
+          npm install @google/adk @google/adk-devtools
+
+      - name: Build @google/adk (required)
+        run: |
+          # If @google/adk is local or needs building
+          cd node_modules/@google/adk || true
+          npm install || true
+          npm run build || true
+          cd ../../../
+
+      - name: Run Auditor Agent Script
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          CONCURRENCY_LIMIT: ${{ secrets.CONCURRENCY_LIMIT }}
+          LLM_MODEL_NAME: ${{ secrets.LLM_MODEL_NAME }}
+          NODE_PATH: dev/samples
+          OWNER: ${{ secrets.OWNER }}
+          REPO: ${{ secrets.REPO }}
+          STALE_LABEL_NAME: ${{ secrets.STALE_LABEL_NAME }}
+          REQUEST_CLARIFICATION_LABEL: ${{ secrets.REQUEST_CLARIFICATION_LABEL }}
+          STALE_HOURS_THRESHOLD: ${{ secrets.STALE_HOURS_THRESHOLD }}
+          CLOSE_HOURS_AFTER_STALE_THRESHOLD: ${{ secrets.CLOSE_HOURS_AFTER_STALE_THRESHOLD }}
+          GRAPHQL_COMMENT_LIMIT: ${{ secrets.GRAPHQL_COMMENT_LIMIT }}
+          GRAPHQL_EDIT_LIMIT: ${{ secrets.GRAPHQL_EDIT_LIMIT }}
+          GRAPHQL_TIMELINE_LIMIT: ${{ secrets.GRAPHQL_TIMELINE_LIMIT }}
+          SLEEP_BETWEEN_CHUNKS: ${{ secrets.SLEEP_BETWEEN_CHUNKS }}
+
+        run: npx tsx dev/samples/adk-stale-agent/main.ts

--- a/dev/samples/adk-stale-agent/PROMPT_INSTRUCTION.txt
+++ b/dev/samples/adk-stale-agent/PROMPT_INSTRUCTION.txt
@@ -1,0 +1,73 @@
+You are a highly intelligent repository auditor for '{OWNER}/{REPO}'.
+Your job is to analyze a specific issue and report findings before taking action.
+
+**Primary Directive:** Ignore any events from users ending in `[bot]`.
+**Reporting Directive:** Output a concise summary starting with "Analysis for Issue #[number]:".
+
+**THRESHOLDS:**
+- Stale Threshold: {stale_threshold_days} days.
+- Close Threshold: {close_threshold_days} days.
+
+**WORKFLOW:**
+1.  **Context Gathering**: Call `get_issue_state`.
+2.  **Decision**: Follow this strict decision tree using the data returned by the tool.
+
+--- **DECISION TREE** ---
+
+**STEP 1: CHECK IF ALREADY STALE**
+- **Condition**: Is `is_stale` (from tool) **True**?
+- **Action**:
+    - **Check Role**: Look at `last_action_role`.
+
+    - **IF 'author' OR 'other_user'**:
+        - **Context**: The user has responded. The issue is now ACTIVE.
+        - **Action 1**: Call `remove_label_from_issue` with '{STALE_LABEL_NAME}'.
+        - **Action 2 (ALERT CHECK)**: Look at `maintainer_alert_needed`.
+            - **IF True**: User edited description silently.
+              -> **Action**: Call `alert_maintainer_of_edit`.
+            - **IF False**: User commented normally. No alert needed.
+        - **Report**: "Analysis for Issue #[number]: ACTIVE. User activity detected. Removed stale label."
+
+    - **IF 'maintainer'**:
+        - **Check Time**: Check `days_since_stale_label`.
+            - **If `days_since_stale_label` > {close_threshold_days}**:
+                - **Action**: Call `close_as_stale`.
+                - **Report**: "Analysis for Issue #[number]: STALE. Close threshold met. Closing."
+            - **Else**:
+                - **Report**: "Analysis for Issue #[number]: STALE. Waiting for close threshold. No action."
+
+**STEP 2: CHECK IF ACTIVE (NOT STALE)**
+- **Condition**: `is_stale` is **False**.
+- **Action**:
+    - **Check Role**: If `last_action_role` is 'author' or 'other_user':
+        - **Context**: The issue is Active.
+        - **Action (ALERT CHECK)**: Look at `maintainer_alert_needed`.
+            - **IF True**: The user edited the description silently, and we haven't alerted yet.
+              -> **Action**: Call `alert_maintainer_of_edit`.
+              -> **Report**: "Analysis for Issue #[number]: ACTIVE. Silent update detected (Description Edit). Alerted maintainer."
+            - **IF False**:
+              -> **Report**: "Analysis for Issue #[number]: ACTIVE. Last action was by user. No action."
+
+    - **Check Role**: If `last_action_role` is 'maintainer':
+      - **Proceed to STEP 3.**
+
+**STEP 3: ANALYZE MAINTAINER INTENT**
+- **Context**: The last person to act was a Maintainer.
+- **Action**: Analyze `last_comment_text` using `maintainers` list and `last_actor_name`.
+
+    - **Internal Discussion Check**: Does the comment mention or address any username found in the `maintainers` list (other than the speaker `last_actor_name`)?
+        - **Verdict**: **ACTIVE** (Internal Team Discussion).
+        - **Report**: "Analysis for Issue #[number]: ACTIVE. Maintainer is discussing with another maintainer. No action."
+
+    - **Question Check**: Does the text ask a question, request clarification, ask for logs, or give suggestions?
+    - **Time Check**: Is `days_since_activity` > {stale_threshold_days}?
+
+    - **DECISION**:
+        - **IF (Question == YES) AND (Time == YES) AND (Internal Discussion Check == FALSE):**
+            - **Action**: Call `add_stale_label_and_comment`.
+            - **Check**: If '{REQUEST_CLARIFICATION_LABEL}' is not in `current_labels`, call `add_label_to_issue` with '{REQUEST_CLARIFICATION_LABEL}'.
+            - **Report**: "Analysis for Issue #[number]: STALE. Maintainer asked question [days_since_activity] days ago. Marking stale."
+        - **IF (Question == YES) BUT (Time == NO)**:
+            - **Report**: "Analysis for Issue #[number]: PENDING. Maintainer asked question, but threshold not met yet. No action."
+        - **IF (Question == NO) OR (Internal Discussion Check == TRUE):**
+            - **Report**: "Analysis for Issue #[number]: ACTIVE. Maintainer gave status update or internal discussion detected. No action."

--- a/dev/samples/adk-stale-agent/agent.ts
+++ b/dev/samples/adk-stale-agent/agent.ts
@@ -5,10 +5,10 @@
  */
 
 import {FunctionTool, LlmAgent} from '@google/adk';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import {parseISO} from 'date-fns';
 import {DateTime} from 'luxon';
+import {readFileSync} from 'node:fs';
+import {fileURLToPath} from 'node:url';
 import {z} from 'zod';
 import {
   CLOSE_HOURS_AFTER_STALE_THRESHOLD,

--- a/dev/samples/adk-stale-agent/agent.ts
+++ b/dev/samples/adk-stale-agent/agent.ts
@@ -9,8 +9,6 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import {parseISO} from 'date-fns';
 import {DateTime} from 'luxon';
-import fs from 'node:fs';
-import path from 'node:path';
 import {z} from 'zod';
 import {
   CLOSE_HOURS_AFTER_STALE_THRESHOLD,

--- a/dev/samples/adk-stale-agent/agent.ts
+++ b/dev/samples/adk-stale-agent/agent.ts
@@ -1,0 +1,748 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {FunctionTool, LlmAgent} from '@google/adk';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import {parseISO} from 'date-fns';
+import {DateTime} from 'luxon';
+import fs from 'node:fs';
+import path from 'node:path';
+import {z} from 'zod';
+import {
+  CLOSE_HOURS_AFTER_STALE_THRESHOLD,
+  GITHUB_BASE_URL,
+  GRAPHQL_COMMENT_LIMIT,
+  GRAPHQL_EDIT_LIMIT,
+  GRAPHQL_TIMELINE_LIMIT,
+  LLM_MODEL_NAME,
+  OWNER,
+  REPO,
+  REQUEST_CLARIFICATION_LABEL,
+  STALE_HOURS_THRESHOLD,
+  STALE_LABEL_NAME,
+} from './settings.js';
+import {
+  deleteRequest,
+  errorResponse,
+  getRequest,
+  patchRequest,
+  postRequest,
+  RequestException,
+} from './utils.js';
+
+export const BOT_ALERT_SIGNATURE =
+  '**Notification:** The author has updated the issue description';
+export const BOT_NAME = 'adk-bot';
+
+// --- Global Cache ---
+let maintainersCache: string[] | null = null;
+
+export interface HistoryEvent {
+  type:
+    | 'created'
+    | 'commented'
+    | 'edited_description'
+    | 'renamed_title'
+    | 'reopened';
+  actor: string | null;
+  time: Date;
+  data: string | null;
+}
+
+export interface IssueState {
+  last_action_role: 'author' | 'maintainer' | 'other_user';
+  last_activity_time: Date;
+  last_action_type: HistoryEvent['type'];
+  last_comment_text: string | null;
+  last_actor_name: string | null;
+}
+
+/**
+ * Replays a unified, chronological history to determine the last actor and state.
+ *
+ * @param history Chronologically sorted events
+ * @param maintainers List of GitHub maintainers
+ * @param issueAuthor Username of the issue author
+ * @returns The last state of the issue
+ */
+export function replayHistoryToFindState(
+  history: HistoryEvent[],
+  maintainers: string[],
+  issueAuthor: string,
+): IssueState {
+  let last_action_role: IssueState['last_action_role'] = 'author';
+  let last_activity_time: Date = history[0]?.time ?? new Date(0);
+  let last_action_type: HistoryEvent['type'] = 'created';
+  let last_comment_text: string | null = null;
+  let last_actor_name: string | null = issueAuthor;
+
+  for (const event of history) {
+    const actor = event.actor;
+    const etype = event.type;
+
+    // Determine role
+    let role: IssueState['last_action_role'] = 'other_user';
+    if (actor === issueAuthor) {
+      role = 'author';
+    } else if (actor && maintainers.includes(actor)) {
+      role = 'maintainer';
+    }
+
+    last_action_role = role;
+    last_activity_time = event.time;
+    last_action_type = etype;
+    last_actor_name = actor;
+
+    // Only store text if it's a comment
+    if (etype === 'commented') {
+      last_comment_text = event.data ?? null;
+    } else {
+      last_comment_text = null;
+    }
+  }
+
+  return {
+    last_action_role,
+    last_activity_time,
+    last_action_type,
+    last_comment_text,
+    last_actor_name,
+  };
+}
+
+export interface IssueGraphQLData {
+  author?: {login: string} | null;
+  createdAt: string;
+  comments?: {
+    nodes: Array<{
+      author?: {login: string} | null;
+      body?: string;
+      createdAt: string;
+      lastEditedAt?: string | null;
+    } | null>;
+  };
+  userContentEdits?: {
+    nodes: Array<{
+      editor?: {login: string} | null;
+      editedAt: string;
+    } | null>;
+  };
+  timelineItems?: {
+    nodes: Array<
+      | {
+          __typename: 'LabeledEvent';
+          createdAt: string;
+          actor?: {login: string} | null;
+          label?: {name: string} | null;
+        }
+      | {
+          __typename: 'RenamedTitleEvent' | 'ReopenedEvent';
+          createdAt: string;
+          actor?: {login: string} | null;
+        }
+      | null
+    >;
+  };
+}
+/**
+ * Parses raw GraphQL issue data into a normalized, chronological history.
+ *
+ * @param data Raw issue object from fetchGraphqlData
+ * @returns [history, labelEvents, lastBotAlertTime]
+ *   - history: array of HistoryEvent objects
+ *   - labelEvents: array of Date when stale label was applied
+ *   - lastBotAlertTime: Date of last bot alert for silent edits, or null
+ */
+export function buildHistoryTimeline(
+  data: IssueGraphQLData,
+): [HistoryEvent[], Date[], Date | null] {
+  const issueAuthor = data.author?.login ?? null;
+  const history: HistoryEvent[] = [];
+  const labelEvents: Date[] = [];
+  let lastBotAlertTime: Date | null = null;
+
+  // 1. Baseline: Issue creation
+  history.push({
+    type: 'created',
+    actor: issueAuthor,
+    time: parseISO(data.createdAt),
+    data: null,
+  });
+
+  // 2. Process comments
+  for (const c of data.comments?.nodes ?? []) {
+    if (!c) continue;
+
+    const actor = c.author?.login ?? null;
+    const cBody = c.body ?? '';
+    const cTime = parseISO(c.createdAt);
+
+    // Track bot alerts for spam prevention
+    if (cBody.includes(BOT_ALERT_SIGNATURE)) {
+      if (!lastBotAlertTime || cTime > lastBotAlertTime) {
+        lastBotAlertTime = cTime;
+      }
+      continue;
+    }
+
+    if (actor && !actor.endsWith('[bot]') && actor !== BOT_NAME) {
+      const actualTime = c.lastEditedAt ? parseISO(c.lastEditedAt) : cTime;
+
+      history.push({
+        type: 'commented',
+        actor,
+        time: actualTime,
+        data: cBody,
+      });
+    }
+  }
+
+  // 3. Process userContentEdits ("Ghost Edits")
+  for (const e of data.userContentEdits?.nodes ?? []) {
+    if (!e) continue;
+    const actor = e.editor?.login ?? null;
+
+    if (actor && !actor.endsWith('[bot]') && actor !== BOT_NAME) {
+      history.push({
+        type: 'edited_description',
+        actor,
+        time: parseISO(e.editedAt),
+        data: null,
+      });
+    }
+  }
+
+  // 4. Process timeline items
+  for (const t of data.timelineItems?.nodes ?? []) {
+    if (!t) continue;
+
+    const etype = t.__typename;
+    const actor = t.actor?.login ?? null;
+    const timeVal = parseISO(t.createdAt);
+
+    if (etype === 'LabeledEvent') {
+      if (t.label?.name === STALE_LABEL_NAME) {
+        labelEvents.push(timeVal);
+      }
+      continue;
+    }
+
+    if (actor && !actor.endsWith('[bot]') && actor !== BOT_NAME) {
+      const prettyType =
+        etype === 'RenamedTitleEvent' ? 'renamed_title' : 'reopened';
+
+      history.push({
+        type: prettyType,
+        actor,
+        time: timeVal,
+        data: null,
+      });
+    }
+  }
+
+  // Sort chronologically
+  history.sort((a, b) => a.time.getTime() - b.time.getTime());
+
+  return [history, labelEvents, lastBotAlertTime];
+}
+
+interface IssueComment {
+  author: {login: string} | null;
+  body: string;
+  createdAt: string;
+  lastEditedAt: string | null;
+}
+
+interface IssueEdit {
+  editor: {login: string} | null;
+  editedAt: string;
+}
+
+interface TimelineItem {
+  __typename: 'LabeledEvent' | 'RenamedTitleEvent' | 'ReopenedEvent';
+  createdAt: string;
+  actor: {login: string} | null;
+  label?: {name: string};
+}
+
+interface Issue {
+  author: {login: string} | null;
+  createdAt: string;
+  labels: {nodes: {name: string}[]};
+  comments: {nodes: IssueComment[]};
+  userContentEdits: {nodes: IssueEdit[]};
+  timelineItems: {nodes: TimelineItem[]};
+}
+
+interface GraphqlResponse {
+  data?: {
+    repository?: {
+      issue?: Issue;
+    };
+  };
+  errors?: {message: string}[];
+}
+
+/**
+ * Fetches raw GitHub issue data using GraphQL, including comments, edits, and timeline events.
+ * Throws RequestException if the issue is not found or GraphQL errors occur.
+ *
+ * @param item_number The GitHub issue number
+ * @returns The raw 'issue' object from the GraphQL response
+ * @throws RequestException
+ */
+async function fetchGraphqlData(item_number: number): Promise<Issue> {
+  const query = `
+    query($owner: String!, $name: String!, $number: Int!, $commentLimit: Int!, $timelineLimit: Int!, $editLimit: Int!) {
+      repository(owner: $owner, name: $name) {
+        issue(number: $number) {
+          author { login }
+          createdAt
+          labels(first: 20) { nodes { name } }
+
+          comments(last: $commentLimit) {
+            nodes {
+              author { login }
+              body
+              createdAt
+              lastEditedAt
+            }
+          }
+
+          userContentEdits(last: $editLimit) {
+            nodes {
+              editor { login }
+              editedAt
+            }
+          }
+
+          timelineItems(itemTypes: [LABELED_EVENT, RENAMED_TITLE_EVENT, REOPENED_EVENT], last: $timelineLimit) {
+            nodes {
+              __typename
+              ... on LabeledEvent {
+                createdAt
+                actor { login }
+                label { name }
+              }
+              ... on RenamedTitleEvent {
+                createdAt
+                actor { login }
+              }
+              ... on ReopenedEvent {
+                createdAt
+                actor { login }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const variables = {
+    owner: OWNER,
+    name: REPO,
+    number: item_number,
+    commentLimit: GRAPHQL_COMMENT_LIMIT,
+    editLimit: GRAPHQL_EDIT_LIMIT,
+    timelineLimit: GRAPHQL_TIMELINE_LIMIT,
+  };
+
+  const response = await postRequest<
+    GraphqlResponse,
+    {query: string; variables: Record<string, unknown>}
+  >(`${GITHUB_BASE_URL}/graphql`, {query, variables});
+
+  if (response.errors && response.errors.length > 0) {
+    throw new RequestException(`GraphQL Error: ${response.errors[0].message}`);
+  }
+
+  const issue = response?.data?.repository?.issue;
+  if (!issue) {
+    throw new RequestException(`Issue #${item_number} not found.`);
+  }
+
+  return issue;
+}
+
+interface GitHubUser {
+  login: string;
+}
+
+/**
+ * Fetches the list of repository maintainers with push access.
+ * Uses caching to prevent repeated API calls.
+ *
+ * Throws an error if API fails or returns invalid data.
+ *
+ * @returns {Promise<string[]>} List of GitHub usernames
+ */
+export async function getCachedMaintainers(): Promise<string[]> {
+  if (maintainersCache) {
+    return maintainersCache;
+  }
+
+  console.info('Initializing Maintainers Cache...');
+
+  try {
+    const url = `${GITHUB_BASE_URL}/repos/${OWNER}/${REPO}/collaborators`;
+    const params = {permission: 'push'};
+
+    const data = await getRequest<GitHubUser[]>(url, params);
+
+    maintainersCache = data.map((u) => u.login);
+
+    console.info(`Cached ${maintainersCache.length} maintainers.`);
+    return maintainersCache;
+  } catch (error: unknown) {
+    console.error(
+      `FATAL: Failed to verify repository maintainers. Error:`,
+      error,
+    );
+    throw new Error('Maintainer verification failed. Processing aborted.');
+  }
+}
+
+/**
+ * Async function to retrieve the comprehensive state of a GitHub issue.
+ */
+async function getIssueState({item_number}: {item_number: number}) {
+  try {
+    // Maintainers cache
+    const maintainers = await getCachedMaintainers();
+
+    //  Fetch issue data via GraphQL
+    const rawData = await fetchGraphqlData(item_number);
+
+    const issueAuthor = rawData.author?.login ?? 'unknown';
+    const labelsList: string[] = rawData.labels?.nodes.map((l) => l.name) || [];
+
+    //  Parse & sort history
+    const [history, labelEvents, lastBotAlertTime] =
+      buildHistoryTimeline(rawData);
+
+    //  Replay history to determine state
+    const state = replayHistoryToFindState(history, maintainers, issueAuthor);
+
+    //  Calculate time-based metrics
+    const currentTime = DateTime.utc();
+    const daysSinceActivity = currentTime.diff(
+      DateTime.fromJSDate(state.last_activity_time),
+      'days',
+    ).days;
+
+    // Stale label logic
+    const isStale = labelsList.includes(STALE_LABEL_NAME);
+    let daysSinceStaleLabel = 0.0;
+    if (isStale && labelEvents.length) {
+      const latestLabelTime = new Date(
+        Math.max(...labelEvents.map((d) => d.getTime())),
+      );
+      daysSinceStaleLabel = currentTime.diff(
+        DateTime.fromJSDate(latestLabelTime),
+        'days',
+      ).days;
+    }
+
+    // Silent edit alert logic
+    let maintainerAlertNeeded = false;
+    if (
+      ['author', 'other_user'].includes(state.last_action_role) &&
+      state.last_action_type === 'edited_description'
+    ) {
+      if (lastBotAlertTime && lastBotAlertTime > state.last_activity_time) {
+        console.info(
+          `#${item_number}: Silent edit detected, but Bot already alerted. No spam.`,
+        );
+      } else {
+        maintainerAlertNeeded = true;
+        console.info(`#${item_number}: Silent edit detected. Alert needed.`);
+      }
+    }
+
+    console.debug(
+      `#${item_number} VERDICT: Role=${state.last_action_role}, Idle=${daysSinceActivity.toFixed(2)}d`,
+    );
+
+    //  Return comprehensive state
+    return {
+      status: 'success',
+      last_action_role: state.last_action_role,
+      last_action_type: state.last_action_type,
+      last_actor_name: state.last_actor_name,
+      maintainer_alert_needed: maintainerAlertNeeded,
+      is_stale: isStale,
+      days_since_activity: daysSinceActivity,
+      days_since_stale_label: daysSinceStaleLabel,
+      last_comment_text: state.last_comment_text,
+      current_labels: labelsList,
+      stale_threshold_days: STALE_HOURS_THRESHOLD / 24,
+      close_threshold_days: CLOSE_HOURS_AFTER_STALE_THRESHOLD / 24,
+      maintainers,
+      issue_author: issueAuthor,
+    };
+  } catch (e: unknown) {
+    if (e instanceof RequestException) {
+      return errorResponse(`Network Error: ${e.message}`);
+    }
+
+    console.error(`Unexpected error analyzing #${item_number}:`, e);
+
+    const message = e instanceof Error ? e.message : String(e);
+    return errorResponse(`Analysis Error: ${message}`);
+  }
+}
+
+export const get_issue_state = new FunctionTool({
+  name: 'get_issue_state',
+  description:
+    'Retrieves the comprehensive state of a GitHub issue, including staleness, activity, and maintainer alerts.',
+  parameters: z.object({
+    item_number: z.number().describe('The GitHub issue number to analyze.'),
+  }),
+  execute: getIssueState,
+});
+
+interface CloseIssuePayload {
+  state: 'closed';
+}
+
+interface SuccessResponse {
+  status: 'success';
+}
+/**
+ * Async function to close a GitHub issue as stale.
+ */
+async function closeAsStale({
+  item_number,
+}: {
+  item_number: number;
+}): Promise<SuccessResponse | ReturnType<typeof errorResponse>> {
+  const days_str = formatDays(CLOSE_HOURS_AFTER_STALE_THRESHOLD);
+
+  const comment = `This has been automatically closed because it has been marked as stale for over ${days_str} days.`;
+
+  try {
+    // Post closure comment — typed payload
+    await postRequest<{id: number}>(
+      `${GITHUB_BASE_URL}/repos/${OWNER}/${REPO}/issues/${item_number}/comments`,
+      {body: comment},
+    );
+
+    // Close the issue — typed payload
+    await patchRequest<{number: number}, CloseIssuePayload>(
+      `${GITHUB_BASE_URL}/repos/${OWNER}/${REPO}/issues/${item_number}`,
+      {state: 'closed'},
+    );
+
+    return {status: 'success'};
+  } catch (error: unknown) {
+    return errorResponse(`Error closing issue: ${error}`);
+  }
+}
+
+export const close_as_stale = new FunctionTool({
+  name: 'close_as_stale',
+  description: 'Closes a GitHub issue that has been marked as stale.',
+  parameters: z.object({
+    item_number: z
+      .number()
+      .describe('The GitHub issue number to close as stale.'),
+  }),
+  execute: closeAsStale,
+});
+
+/**
+ * Async function to alert maintainers of an issue description edit.
+ */
+async function alertMaintainerOfEdit({item_number}: {item_number: number}) {
+  const comment = `${BOT_ALERT_SIGNATURE}. Maintainers, please review.`;
+
+  try {
+    await postRequest<{id: number}, {body: string}>(
+      `${GITHUB_BASE_URL}/repos/${OWNER}/${REPO}/issues/${item_number}/comments`,
+      {body: comment},
+    );
+
+    return {status: 'success'};
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    return errorResponse(`Error posting alert: ${message}`);
+  }
+}
+
+export const alert_maintainer_of_edit = new FunctionTool({
+  name: 'alert_maintainer_of_edit',
+  description:
+    'Posts a comment alerting maintainers of a silent description update.',
+  parameters: z.object({
+    item_number: z
+      .number()
+      .describe('The GitHub issue number to alert maintainers about.'),
+  }),
+  execute: alertMaintainerOfEdit,
+});
+
+/**
+ * Formats a duration in hours into a clean day string.
+ *
+ * Examples:
+ *   168 -> "7"
+ *   12  -> "0.5"
+ */
+function formatDays(hours: number): string {
+  const days = hours / 24;
+  // Return integer if whole, otherwise one decimal
+  return days % 1 === 0 ? `${days}` : days.toFixed(1);
+}
+
+async function addStaleLabelAndComment({item_number}: {item_number: number}) {
+  const stale_days_str = formatDays(STALE_HOURS_THRESHOLD);
+  const close_days_str = formatDays(CLOSE_HOURS_AFTER_STALE_THRESHOLD);
+
+  const comment = `This issue has been automatically marked as stale because it has not had recent activity for ${stale_days_str} days after a maintainer requested clarification. It will be closed if no further activity occurs within ${close_days_str} days.`;
+
+  try {
+    // Add comment
+    await postRequest<{id: number}, {body: string}>(
+      `${GITHUB_BASE_URL}/repos/${OWNER}/${REPO}/issues/${item_number}/comments`,
+      {body: comment},
+    );
+
+    // Add stale label
+    await postRequest<{name: string}[], string[]>(
+      `${GITHUB_BASE_URL}/repos/${OWNER}/${REPO}/issues/${item_number}/labels`,
+      [STALE_LABEL_NAME],
+    );
+
+    return {status: 'success'};
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    return errorResponse(`Error marking issue as stale: ${message}`);
+  }
+}
+
+const add_stale_label_and_comment = new FunctionTool({
+  name: 'add_stale_label_and_comment',
+  description: 'Marks a GitHub issue as stale with a comment and label.',
+  parameters: z.object({
+    item_number: z
+      .number()
+      .describe('The GitHub issue number to mark as stale.'),
+  }),
+  execute: addStaleLabelAndComment,
+});
+
+async function addLabelToIssue({
+  item_number,
+  label_name,
+}: {
+  item_number: number;
+  label_name: string;
+}) {
+  console.debug(`Adding label '${label_name}' to issue #${item_number}.`);
+
+  const url = `${GITHUB_BASE_URL}/repos/${OWNER}/${REPO}/issues/${item_number}/labels`;
+
+  try {
+    await postRequest<number[], string[]>(url, [label_name]);
+    return {status: 'success'};
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    return errorResponse(`Error adding label: ${message}`);
+  }
+}
+
+const add_label_to_issue = new FunctionTool({
+  name: 'add_label_to_issue',
+  description: 'Adds a label to a GitHub issue.',
+  parameters: z.object({
+    item_number: z
+      .number()
+      .describe('The GitHub issue number to which the label should be added.'),
+    label_name: z.string().describe('The name of the label to add.'),
+  }),
+  execute: addLabelToIssue,
+});
+
+export async function removeLabelFromIssue({
+  item_number,
+  label_name,
+}: {
+  item_number: number;
+  label_name: string;
+}) {
+  console.debug(`Removing label '${label_name}' from issue #${item_number}.`);
+
+  const url = `${GITHUB_BASE_URL}/repos/${OWNER}/${REPO}/issues/${item_number}/labels/${label_name}`;
+
+  try {
+    await deleteRequest(url);
+    return {status: 'success'};
+  } catch (error: unknown) {
+    return errorResponse(`Error removing label: ${error}`);
+  }
+}
+
+export const remove_label_from_issue = new FunctionTool({
+  name: 'remove_label_from_issue',
+  description: 'Removes a label from a GitHub issue.',
+  parameters: z.object({
+    item_number: z
+      .number()
+      .describe(
+        'The GitHub issue number from which the label should be removed.',
+      ),
+    label_name: z.string().describe('The name of the label to remove.'),
+  }),
+  execute: removeLabelFromIssue,
+});
+
+/**
+ * Loads the raw text content of a prompt file.
+ *
+ * @param filename - The name of the file (e.g., "PROMPT_INSTRUCTION.txt")
+ * @returns The file content
+ */
+export function loadPromptTemplate(filename: string): string {
+  // Resolve path relative to the current module file
+  const filePath = new URL(filename, import.meta.url);
+  return readFileSync(fileURLToPath(filePath), 'utf-8');
+}
+
+function formatPrompt(
+  template: string,
+  vars: Record<string, string | number>,
+): string {
+  return template.replace(/\{(\w+)\}/g, (_, key) =>
+    String(vars[key] ?? `{${key}}`),
+  );
+}
+
+const PROMPT_TEMPLATE = loadPromptTemplate('PROMPT_INSTRUCTION.txt');
+
+export const rootAgent = new LlmAgent({
+  model: LLM_MODEL_NAME,
+  name: 'adk_repository_auditor_agent',
+  description: 'Audits open issues.',
+  instruction: formatPrompt(PROMPT_TEMPLATE, {
+    OWNER,
+    REPO,
+    STALE_LABEL_NAME,
+    REQUEST_CLARIFICATION_LABEL,
+    stale_threshold_days: STALE_HOURS_THRESHOLD / 24,
+    close_threshold_days: CLOSE_HOURS_AFTER_STALE_THRESHOLD / 24,
+  }),
+  tools: [
+    add_label_to_issue,
+    add_stale_label_and_comment,
+    alert_maintainer_of_edit,
+    close_as_stale,
+    get_issue_state,
+    remove_label_from_issue,
+  ],
+});

--- a/dev/samples/adk-stale-agent/main.ts
+++ b/dev/samples/adk-stale-agent/main.ts
@@ -1,0 +1,173 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {InMemoryRunner} from '@google/adk';
+import {rootAgent} from './agent.js';
+import {
+  CONCURRENCY_LIMIT,
+  OWNER,
+  REPO,
+  SLEEP_BETWEEN_CHUNKS,
+  STALE_HOURS_THRESHOLD,
+} from './settings.js';
+import {
+  getApiCallCount,
+  getOldOpenIssueNumbers,
+  resetApiCallCount,
+} from './utils.js';
+
+export const APP_NAME = 'stale_bot_app';
+export const USER_ID = 'stale_bot_user';
+
+async function processSingleIssue(
+  issueNumber: number,
+): Promise<[number, number]> {
+  const startTime = performance.now();
+  const startApiCalls = getApiCallCount();
+
+  console.info(`Processing Issue #${issueNumber}...`);
+  console.debug(`#${issueNumber}: Initializing runner and session.`);
+
+  try {
+    const runner = new InMemoryRunner({agent: rootAgent, appName: APP_NAME});
+
+    const session = await runner.sessionService.createSession({
+      userId: USER_ID,
+      appName: APP_NAME,
+    });
+
+    const newMessage = {
+      role: 'user',
+      parts: [{text: `Audit Issue #${issueNumber}.`}],
+    };
+
+    for await (const event of runner.runAsync({
+      userId: USER_ID,
+      sessionId: session.id,
+      newMessage,
+    })) {
+      // Access text via event.content.parts
+      const text = event.content?.parts?.[0]?.text;
+
+      if (text) {
+        const cleanText = text.slice(0, 150).replace(/\n/g, ' ');
+        console.info(`#${issueNumber} Decision: ${cleanText}...`);
+      }
+    }
+  } catch (error) {
+    console.error(`Error processing issue #${issueNumber}:`, error);
+  }
+
+  const duration = (performance.now() - startTime) / 1000;
+  const endApiCalls = getApiCallCount();
+  const issueApiCalls = endApiCalls - startApiCalls;
+
+  console.info(
+    `Issue #${issueNumber} finished in ${duration.toFixed(
+      2,
+    )}s with ~${issueApiCalls} API calls.`,
+  );
+
+  return [duration, issueApiCalls];
+}
+
+async function main() {
+  console.info(`--- Starting Stale Bot for ${OWNER}/${REPO} ---`);
+  console.info(`Concurrency level set to ${CONCURRENCY_LIMIT}`);
+
+  resetApiCallCount();
+
+  const filterDays = STALE_HOURS_THRESHOLD / 24;
+  console.debug(`Fetching issues older than ${filterDays.toFixed(2)} days...`);
+
+  let allIssues;
+
+  try {
+    allIssues = await getOldOpenIssueNumbers(OWNER, REPO, filterDays);
+  } catch (error) {
+    console.error('Failed to fetch issue list:', error);
+    return;
+  }
+
+  const totalCount = allIssues.length;
+  const searchApiCalls = getApiCallCount();
+
+  if (totalCount === 0) {
+    console.info('No issues matched the criteria. Run finished.');
+    return;
+  }
+
+  console.info(
+    `Found ${totalCount} issues to process. ` +
+      `(Initial search used ${searchApiCalls} API calls).`,
+  );
+
+  let totalProcessingTime = 0;
+  let totalIssueApiCalls = 0;
+  let processedCount = 0;
+
+  for (let i = 0; i < totalCount; i += CONCURRENCY_LIMIT) {
+    const chunk = allIssues.slice(i, i + CONCURRENCY_LIMIT);
+    const currentChunkNum = Math.floor(i / CONCURRENCY_LIMIT) + 1;
+
+    console.info(
+      `--- Starting chunk ${currentChunkNum}: Processing issues ${chunk} ---`,
+    );
+
+    const results = await Promise.all(
+      chunk.map((issueNum) => processSingleIssue(issueNum)),
+    );
+
+    for (const [duration, apiCalls] of results) {
+      totalProcessingTime += duration;
+      totalIssueApiCalls += apiCalls;
+    }
+
+    processedCount += chunk.length;
+
+    console.info(
+      `--- Finished chunk ${currentChunkNum}. Progress: ` +
+        `${processedCount}/${totalCount} ---`,
+    );
+
+    if (i + CONCURRENCY_LIMIT < totalCount) {
+      console.debug(
+        `Sleeping for ${SLEEP_BETWEEN_CHUNKS}s to respect rate limits...`,
+      );
+
+      await new Promise((resolve) =>
+        setTimeout(resolve, SLEEP_BETWEEN_CHUNKS * 1000),
+      );
+    }
+  }
+
+  const totalApiCallsForRun = searchApiCalls + totalIssueApiCalls;
+
+  const avgTimePerIssue = totalCount > 0 ? totalProcessingTime / totalCount : 0;
+
+  console.info('--- Stale Agent Run Finished ---');
+  console.info(`Successfully processed ${processedCount} issues.`);
+  console.info(`Total API calls made this run: ${totalApiCallsForRun}`);
+  console.info(
+    `Average processing time per issue: ${avgTimePerIssue.toFixed(2)} seconds.`,
+  );
+}
+
+async function run() {
+  const startTime = performance.now();
+
+  try {
+    await main();
+  } catch (error) {
+    console.error('Unexpected fatal error:', error);
+  }
+
+  const duration = (performance.now() - startTime) / 1000;
+
+  console.info(`Full audit finished in ${(duration / 60).toFixed(2)} minutes.`);
+}
+
+run();

--- a/dev/samples/adk-stale-agent/settings.ts
+++ b/dev/samples/adk-stale-agent/settings.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as dotenv from 'dotenv';
+
+// # Load environment variables from a .env file for local testing
+dotenv.config({override: true});
+
+// # --- GitHub API Configuration ---
+export const GITHUB_BASE_URL = 'https://api.github.com';
+export const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+
+if (!GITHUB_TOKEN) {
+  throw new Error('GITHUB_TOKEN environment variable not set');
+}
+
+export const OWNER = process.env.OWNER ?? '';
+export const REPO = process.env.REPO ?? '';
+export const LLM_MODEL_NAME = process.env.LLM_MODEL_NAME ?? '';
+export const STALE_LABEL_NAME = process.env.STALE_LABEL_NAME ?? '';
+export const REQUEST_CLARIFICATION_LABEL =
+  process.env.REQUEST_CLARIFICATION_LABEL ?? '';
+
+// # --- THRESHOLDS IN HOURS ---
+// # Default: 168 hours (7 days)
+// # The number of hours of inactivity after a maintainer comment before an issue is marked as stale.
+export const STALE_HOURS_THRESHOLD: number = parseFloat(
+  process.env.STALE_HOURS_THRESHOLD ?? '168',
+);
+
+// # Default: 168 hours (7 days)
+// # The number of hours of inactivity after an issue is marked 'stale' before it is closed.
+export const CLOSE_HOURS_AFTER_STALE_THRESHOLD: number = parseFloat(
+  process.env.CLOSE_HOURS_AFTER_STALE_THRESHOLD ?? '168',
+);
+
+// # --- Performance Configuration ---
+// # The number of issues to process concurrently.
+// # Higher values are faster but increase the immediate rate of API calls
+export const CONCURRENCY_LIMIT: number = parseInt(
+  process.env.CONCURRENCY_LIMIT ?? '3',
+  10,
+);
+
+// # --- GraphQL Query Limits ---
+// # The number of most recent comments to fetch for context analysis.
+export const GRAPHQL_COMMENT_LIMIT: number = parseInt(
+  process.env.GRAPHQL_COMMENT_LIMIT ?? '30',
+  10,
+);
+
+// # The number of most recent description edits to fetch.
+export const GRAPHQL_EDIT_LIMIT: number = parseInt(
+  process.env.GRAPHQL_EDIT_LIMIT ?? '10',
+  10,
+);
+
+// # The number of most recent timeline events (labels, renames, reopens) to fetch.
+export const GRAPHQL_TIMELINE_LIMIT: number = parseInt(
+  process.env.GRAPHQL_TIMELINE_LIMIT ?? '20',
+  10,
+);
+
+// # --- Rate Limiting ---
+// # Time in seconds to wait between processing chunks.
+export const SLEEP_BETWEEN_CHUNKS: number = parseFloat(
+  process.env.SLEEP_BETWEEN_CHUNKS ?? '1.5',
+);

--- a/dev/samples/adk-stale-agent/utils.ts
+++ b/dev/samples/adk-stale-agent/utils.ts
@@ -1,0 +1,212 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import axios, {AxiosError, AxiosInstance} from 'axios';
+import axiosRetry from 'axios-retry';
+import {GITHUB_TOKEN, STALE_HOURS_THRESHOLD} from './settings.js';
+
+export class RequestException extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RequestException';
+  }
+}
+
+// API Call Counter & Utilities
+let _apiCallCount = 0;
+
+//Returns the total number of API calls made since the last reset.
+export function getApiCallCount(): number {
+  return _apiCallCount;
+}
+
+// Resets the global API call counter to zero.
+export function resetApiCallCount(): void {
+  _apiCallCount = 0;
+}
+
+// Increments the global API call counter.
+
+// Needed if agent or tools run concurrently.
+export function incrementApiCallCount(): void {
+  _apiCallCount += 1;
+}
+
+const httpClient: AxiosInstance = axios.create({
+  timeout: 60_000, // 60 seconds
+  headers: {
+    Authorization: `token ${GITHUB_TOKEN}`,
+    Accept: 'application/vnd.github.v3+json',
+  },
+});
+
+/* ----------------------------------
+ * Retry Strategy (Exponential Backoff)
+ * ---------------------------------- */
+
+axiosRetry(httpClient, {
+  retries: 6,
+  retryDelay: axiosRetry.exponentialDelay,
+  retryCondition: (error: AxiosError) => {
+    const status = error.response?.status;
+    return status !== undefined && [429, 500, 502, 503, 504].includes(status);
+  },
+});
+
+export async function getRequest<T>(
+  url: string,
+  params?: Record<string, unknown>,
+): Promise<T> {
+  incrementApiCallCount();
+  try {
+    const response = await httpClient.get<T>(url, {params});
+    return response.data;
+  } catch (error: unknown) {
+    console.error(`GET request failed for ${url}:`, error);
+    throw error;
+  }
+}
+
+export async function postRequest<T, P = Record<string, unknown>>(
+  url: string,
+  payload: P,
+): Promise<T> {
+  incrementApiCallCount();
+  try {
+    const response = await httpClient.post<T>(url, payload);
+    return response.data;
+  } catch (error: unknown) {
+    console.error(`POST request failed for ${url}:`, error);
+    throw error;
+  }
+}
+
+export async function patchRequest<T, P = Record<string, unknown>>(
+  url: string,
+  payload: P,
+): Promise<T> {
+  incrementApiCallCount();
+  try {
+    const response = await httpClient.patch<T>(url, payload);
+    return response.data;
+  } catch (error: unknown) {
+    console.error(`PATCH request failed for ${url}:`, error);
+    throw error;
+  }
+}
+
+export async function deleteRequest<T = unknown>(
+  url: string,
+): Promise<T | {status: string; message: string}> {
+  incrementApiCallCount();
+  try {
+    const response = await httpClient.delete<T>(url);
+
+    if (response.status === 204) {
+      return {
+        status: 'success',
+        message: 'Deletion successful.',
+      };
+    }
+
+    return response.data;
+  } catch (error: unknown) {
+    console.error(`DELETE request failed for ${url}:`, error);
+    throw error;
+  }
+}
+
+export function errorResponse(errorMessage: string): {
+  status: string;
+  message: string;
+} {
+  return {
+    status: 'error',
+    message: errorMessage,
+  };
+}
+
+// --- GitHub search issues response ---
+interface GitHubIssueItem {
+  number: number;
+  pull_request?: unknown; // present if it's a PR
+}
+
+interface GitHubSearchIssuesResponse {
+  total_count: number;
+  items: GitHubIssueItem[];
+}
+
+/**
+ * Finds open issues older than the specified threshold using server-side filtering.
+ *
+ * OPTIMIZATION:
+ * Uses the GitHub Search API `created:<DATE` syntax instead of client-side filtering.
+ *
+ * @param owner Repository owner
+ * @param repo Repository name
+ * @param daysOld Filter issues older than this many days.
+ *                Defaults to STALE_HOURS_THRESHOLD / 24.
+ * @returns A list of issue numbers matching the criteria.
+ */
+export async function getOldOpenIssueNumbers(
+  owner: string,
+  repo: string,
+  daysOld?: number,
+): Promise<number[]> {
+  if (daysOld == null) {
+    daysOld = STALE_HOURS_THRESHOLD / 24;
+  }
+
+  const nowUtc = new Date();
+  const cutoffMs = daysOld * 24 * 60 * 60 * 1000;
+  const cutoffDate = new Date(nowUtc.getTime() - cutoffMs);
+
+  const cutoffStr = cutoffDate.toISOString().replace(/\.\d{3}Z$/, 'Z');
+
+  const query = `repo:${owner}/${repo} is:issue state:open created:<${cutoffStr}`;
+
+  console.log(
+    `Searching for issues in '${owner}/${repo}' created before ${cutoffStr}...`,
+  );
+
+  const issueNumbers: number[] = [];
+  let page = 1;
+  const url = 'https://api.github.com/search/issues';
+
+  while (true) {
+    try {
+      const params = {
+        q: query,
+        per_page: 100,
+        page,
+      };
+
+      const data = await getRequest<GitHubSearchIssuesResponse>(url, params);
+
+      const items = data.items ?? [];
+
+      if (items.length === 0) break;
+
+      for (const item of items) {
+        // Exclude pull requests
+        if (!('pull_request' in item)) {
+          issueNumbers.push(item.number);
+        }
+      }
+
+      if (items.length < 100) break;
+
+      page += 1;
+    } catch (error: unknown) {
+      console.error(`GitHub search failed on page ${page}:`, error);
+      break;
+    }
+  }
+
+  console.log(`Found ${issueNumbers.length} stale issues.`);
+  return issueNumbers;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,20 @@
         "core",
         "dev"
       ],
+      "dependencies": {
+        "@google/adk": "^0.3.0",
+        "@google/adk-devtools": "^0.3.0",
+        "axios": "^1.13.5",
+        "axios-retry": "^4.5.0",
+        "date-fns": "^4.1.0",
+        "luxon": "^3.7.2"
+      },
       "devDependencies": {
         "@eslint/js": "^9.37.0",
         "@secretlint/secretlint-rule-pattern": "^11.3.1",
         "@secretlint/secretlint-rule-preset-recommend": "^11.3.1",
-        "@types/node": "^20.12.7",
+        "@types/luxon": "^3.7.1",
+        "@types/node": "^20.19.33",
         "@vitest/coverage-v8": "^3.2.4",
         "concurrently": "^9.2.1",
         "esbuild": "^0.25.9",
@@ -29,9 +38,10 @@
         "prettier": "^3.6.2",
         "prettier-plugin-organize-imports": "^4.3.0",
         "secretlint": "^11.3.1",
+        "ts-node": "^10.9.2",
         "typedoc": "^0.28.16",
         "typedoc-theme-fresh": "^0.2.3",
-        "typescript": "^5.9.2",
+        "typescript": "^5.9.3",
         "typescript-eslint": "^8.46.0",
         "vitest": "^3.2.4"
       }
@@ -152,6 +162,7 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -233,6 +244,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -431,6 +443,30 @@
         "@clack/core": "0.5.0",
         "picocolors": "^1.0.0",
         "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1015,7 +1051,6 @@
       "resolved": "https://registry.npmjs.org/@google-cloud/opentelemetry-cloud-monitoring-exporter/-/opentelemetry-cloud-monitoring-exporter-0.21.0.tgz",
       "integrity": "sha512-+lAew44pWt6rA4l8dQ1gGhH7Uo95wZKfq/GBf9aEyuNDDLQ2XppGEEReu6ujesSqTtZ8ueQFt73+7SReSHbwqg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@google-cloud/opentelemetry-resource-util": "^3.0.0",
         "@google-cloud/precise-date": "^4.0.0",
@@ -1037,7 +1072,6 @@
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
       "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
@@ -1055,7 +1089,6 @@
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
       "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "gaxios": "^6.0.0",
         "jws": "^4.0.0"
@@ -1069,7 +1102,6 @@
       "resolved": "https://registry.npmjs.org/@google-cloud/opentelemetry-cloud-trace-exporter/-/opentelemetry-cloud-trace-exporter-3.0.0.tgz",
       "integrity": "sha512-mUfLJBFo+ESbO0dAGboErx2VyZ7rbrHcQvTP99yH/J72dGaPbH2IzS+04TFbTbEd1VW5R9uK3xq2CqawQaG+1Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@google-cloud/opentelemetry-resource-util": "^3.0.0",
         "@grpc/grpc-js": "^1.1.8",
@@ -1091,7 +1123,6 @@
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
       "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
@@ -1109,7 +1140,6 @@
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
       "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "gaxios": "^6.0.0",
         "jws": "^4.0.0"
@@ -1123,7 +1153,6 @@
       "resolved": "https://registry.npmjs.org/@google-cloud/opentelemetry-resource-util/-/opentelemetry-resource-util-3.0.0.tgz",
       "integrity": "sha512-CGR/lNzIfTKlZoZFfS6CkVzx+nsC9gzy6S8VcyaLegfEJbiPjxbMLP7csyhJTvZe/iRRcQJxSk0q8gfrGqD3/Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.22.0",
         "gcp-metadata": "^6.0.0"
@@ -1141,7 +1170,6 @@
       "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
       "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "arrify": "^2.0.0",
         "extend": "^3.0.2"
@@ -1155,7 +1183,6 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1165,7 +1192,6 @@
       "resolved": "https://registry.npmjs.org/@google-cloud/precise-date/-/precise-date-4.0.0.tgz",
       "integrity": "sha512-1TUx3KdaU3cN7nfCdNf+UVqA/PSX29Cjcox3fZZBtINlRrXVTmUkQnCKv2MbBUbCopbK4olAT1IHl76uZyCiVA==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -1175,7 +1201,6 @@
       "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
       "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -1185,7 +1210,6 @@
       "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
       "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -1195,7 +1219,6 @@
       "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.19.0.tgz",
       "integrity": "sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@google-cloud/paginator": "^5.0.0",
         "@google-cloud/projectify": "^4.0.0",
@@ -1222,7 +1245,6 @@
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
       "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
@@ -1240,7 +1262,6 @@
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
       "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "gaxios": "^6.0.0",
         "jws": "^4.0.0"
@@ -1254,7 +1275,6 @@
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
       "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -1297,7 +1317,6 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
       "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -1311,7 +1330,6 @@
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
       "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
@@ -1563,7 +1581,6 @@
       "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
       "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
@@ -1574,6 +1591,7 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
       "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -1974,7 +1992,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.5.0.tgz",
       "integrity": "sha512-uOXpVX0ZjO7heSVjhheW2XEPrhQAWr2BScDPoZ9UDycl5iuHG+Usyc3AIfG6kZeC1GyLpMInpQ6X5+9n69yOFw==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -2003,7 +2020,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.205.0.tgz",
       "integrity": "sha512-5JteMyVWiro4ghF0tHQjfE6OJcF7UBUcoEqX3UIQ5jutKP1H+fxFdyhqjjpmeHMFxzOHaYuLlNR1Bn7FOjGyJg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.205.0",
         "@opentelemetry/core": "2.1.0",
@@ -2023,7 +2039,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
       "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2039,7 +2054,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.205.0.tgz",
       "integrity": "sha512-fFxNQ/HbbpLmh1pgU6HUVbFD1kNIjrkoluoKJkh88+gnmpFD92kMQ8WFNjPnSbjg2mNVnEkeKXgCYEowNW+p1w==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.1.0",
         "@opentelemetry/otlp-exporter-base": "0.205.0",
@@ -2059,7 +2073,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
       "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2075,7 +2088,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
       "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.1.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -2092,7 +2104,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.1.0.tgz",
       "integrity": "sha512-J9QX459mzqHLL9Y6FZ4wQPRZG4TOpMCyPOh6mkr/humxE1W2S3Bvf4i75yiMW9uyed2Kf5rxmLhTm/UK8vNkAw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.1.0",
         "@opentelemetry/resources": "2.1.0"
@@ -2109,7 +2120,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.205.0.tgz",
       "integrity": "sha512-vr2bwwPCSc9u7rbKc74jR+DXFvyMFQo9o5zs+H/fgbK672Whw/1izUKVf+xfWOdJOvuwTnfWxy+VAY+4TSo74Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.1.0",
         "@opentelemetry/otlp-exporter-base": "0.205.0",
@@ -2129,7 +2139,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
       "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2145,7 +2154,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
       "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.1.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -2162,7 +2170,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.1.0.tgz",
       "integrity": "sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.1.0",
         "@opentelemetry/resources": "2.1.0",
@@ -2180,7 +2187,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.205.0.tgz",
       "integrity": "sha512-2MN0C1IiKyo34M6NZzD6P9Nv9Dfuz3OJ3rkZwzFmF6xzjDfqqCTatc9v1EpNfaP55iDOCLHFyYNCgs61FFgtUQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.1.0",
         "@opentelemetry/otlp-transformer": "0.205.0"
@@ -2197,7 +2203,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
       "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2213,7 +2218,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.205.0.tgz",
       "integrity": "sha512-KmObgqPtk9k/XTlWPJHdMbGCylRAmMJNXIRh6VYJmvlRDMfe+DonH41G7eenG8t4FXn3fxOGh14o/WiMRR6vPg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.205.0",
         "@opentelemetry/core": "2.1.0",
@@ -2235,7 +2239,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
       "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2251,7 +2254,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
       "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.1.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -2268,7 +2270,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.1.0.tgz",
       "integrity": "sha512-J9QX459mzqHLL9Y6FZ4wQPRZG4TOpMCyPOh6mkr/humxE1W2S3Bvf4i75yiMW9uyed2Kf5rxmLhTm/UK8vNkAw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.1.0",
         "@opentelemetry/resources": "2.1.0"
@@ -2285,7 +2286,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.1.0.tgz",
       "integrity": "sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.1.0",
         "@opentelemetry/resources": "2.1.0",
@@ -2338,7 +2338,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.205.0.tgz",
       "integrity": "sha512-nyqhNQ6eEzPWQU60Nc7+A5LIq8fz3UeIzdEVBQYefB4+msJZ2vuVtRuk9KxPMw1uHoHDtYEwkr2Ct0iG29jU8w==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.205.0",
         "@opentelemetry/core": "2.1.0",
@@ -2356,7 +2355,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
       "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2372,7 +2370,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
       "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.1.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -2442,7 +2439,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.39.0.tgz",
       "integrity": "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -3261,10 +3257,37 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
@@ -3281,8 +3304,7 @@
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
       "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3396,6 +3418,13 @@
         "@types/lodash": "*"
       }
     },
+    "node_modules/@types/luxon": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
+      "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -3411,10 +3440,11 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.32.tgz",
-      "integrity": "sha512-Ez8QE4DMfhjjTsES9K2dwfV258qBui7qxUsoaixZDiTzbde4U12e1pXGNu/ECsUIOi5/zoCxAQxIhQnaUQ2VvA==",
+      "version": "20.19.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
+      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3445,7 +3475,6 @@
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
       "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/caseless": "*",
         "@types/node": "*",
@@ -3497,8 +3526,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -3628,6 +3656,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -4387,7 +4416,6 @@
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -4414,6 +4442,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4429,6 +4458,19 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -4549,6 +4591,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -4626,7 +4675,6 @@
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
       "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "retry": "0.13.1"
       }
@@ -4635,8 +4683,46 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
-      "peer": true
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios-retry": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
+      "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-retry-allowed": "^2.2.0"
+      },
+      "peerDependencies": {
+        "axios": "0.x || 1.x"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -5079,7 +5165,6 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -5207,6 +5292,13 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5228,6 +5320,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -5306,7 +5408,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -5328,6 +5429,16 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dir-glob": {
@@ -5387,7 +5498,6 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
       "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "end-of-stream": "^1.4.1",
         "inherits": "^2.0.3",
@@ -5453,7 +5563,6 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -5536,7 +5645,6 @@
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -6060,7 +6168,6 @@
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -6132,6 +6239,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -6311,7 +6419,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "strnum": "^2.1.0"
       },
@@ -6480,7 +6587,6 @@
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
       "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -6530,7 +6636,6 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
       "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -6609,7 +6714,6 @@
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
       "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
@@ -6630,7 +6734,6 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -6640,7 +6743,6 @@
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
       "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "gaxios": "^6.1.1",
         "google-logging-utils": "^0.0.2",
@@ -6930,7 +7032,6 @@
       "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
       "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -6940,7 +7041,6 @@
       "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-137.1.0.tgz",
       "integrity": "sha512-2L7SzN0FLHyQtFmyIxrcXhgust77067pkkduqkbIpDuj9JzVnByxsRrcRfUMFQam3rQkWW2B0f1i40IwKDWIVQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "google-auth-library": "^9.0.0",
         "googleapis-common": "^7.0.0"
@@ -6954,7 +7054,6 @@
       "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
       "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "extend": "^3.0.2",
         "gaxios": "^6.0.3",
@@ -6972,7 +7071,6 @@
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
       "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
@@ -6990,7 +7088,6 @@
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
       "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "gaxios": "^6.0.0",
         "jws": "^4.0.0"
@@ -7008,7 +7105,6 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -7018,7 +7114,6 @@
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
       "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
@@ -7036,7 +7131,6 @@
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
       "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "gaxios": "^6.0.0",
         "jws": "^4.0.0"
@@ -7270,6 +7364,7 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -7446,6 +7541,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -7588,7 +7684,6 @@
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -7626,6 +7721,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
       "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7670,8 +7766,7 @@
           "url": "https://patreon.com/mdevils"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -7720,7 +7815,6 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tootallnate/once": "2",
         "agent-base": "6",
@@ -7735,7 +7829,6 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -8060,6 +8153,18 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -8406,8 +8511,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -8604,6 +8708,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -8641,6 +8754,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/map-obj": {
       "version": "4.3.0",
@@ -9003,7 +9123,6 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -9453,6 +9572,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9529,6 +9649,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -9778,7 +9904,6 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -9890,7 +10015,6 @@
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -9900,7 +10024,6 @@
       "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
       "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/request": "^2.48.8",
         "extend": "^3.0.2",
@@ -10585,7 +10708,6 @@
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
       "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "stubs": "^3.0.0"
       }
@@ -10594,15 +10716,13 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
       "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -10755,8 +10875,7 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/structured-source": {
       "version": "4.0.0",
@@ -10772,8 +10891,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -10909,7 +11027,6 @@
       "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
       "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
@@ -10926,7 +11043,6 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -10939,7 +11055,6 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -10957,7 +11072,6 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -11143,6 +11257,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11219,8 +11334,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -11266,6 +11380,50 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ts-graphviz"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
       }
     },
     "node_modules/tslib": {
@@ -11406,6 +11564,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11618,15 +11777,13 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
       "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
-      "license": "BSD",
-      "peer": true
+      "license": "BSD"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -11642,10 +11799,16 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -11686,6 +11849,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -12286,6 +12450,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12299,6 +12464,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -12392,8 +12558,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-encoding": {
       "version": "2.0.0",
@@ -12427,7 +12592,6 @@
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -12688,6 +12852,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -12705,6 +12879,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "@eslint/js": "^9.37.0",
     "@secretlint/secretlint-rule-pattern": "^11.3.1",
     "@secretlint/secretlint-rule-preset-recommend": "^11.3.1",
-    "@types/node": "^20.12.7",
+    "@types/luxon": "^3.7.1",
+    "@types/node": "^20.19.33",
     "@vitest/coverage-v8": "^3.2.4",
     "concurrently": "^9.2.1",
     "esbuild": "^0.25.9",
@@ -51,9 +52,10 @@
     "prettier": "^3.6.2",
     "prettier-plugin-organize-imports": "^4.3.0",
     "secretlint": "^11.3.1",
+    "ts-node": "^10.9.2",
     "typedoc": "^0.28.16",
     "typedoc-theme-fresh": "^0.2.3",
-    "typescript": "^5.9.2",
+    "typescript": "^5.9.3",
     "typescript-eslint": "^8.46.0",
     "vitest": "^3.2.4"
   },
@@ -68,5 +70,13 @@
     "**/*.{json,md}": [
       "prettier --write"
     ]
+  },
+  "dependencies": {
+    "@google/adk": "^0.3.0",
+    "@google/adk-devtools": "^0.3.0",
+    "axios": "^1.13.5",
+    "axios-retry": "^4.5.0",
+    "date-fns": "^4.1.0",
+    "luxon": "^3.7.2"
   }
 }


### PR DESCRIPTION
**Add Stale Issue Auditor GitHub Action**
This PR adds a GitHub Actions workflow that checks for inactive issues and automatically manages stale labels. It can alert maintainers, mark issues as stale, or close them when needed, keeping the repository clean and up-to-date.

**How It Works**

**1. Trigger Events**

- Runs when an issue is updated or commented on.
- Ignores actions from users ending with bot.

**2. Issue Check**

- Looks at whether an issue is already stale.
- Checks who last acted (author, other user, or maintainer).
- Uses thresholds to decide when to mark as stale or close.

**3. Automated Actions**

- Remove stale label if the user responds.
- Alert maintainers if a user silently edits the issue.
- Add stale label and comment if a maintainer’s question isn’t answered.
- Close issue if it stays stale too long.

**Why This Is Needed**

- Keeps the repository organized.
- Saves time by automatically handling inactive issues.
- Makes sure maintainers know about changes or inactivity.
